### PR TITLE
Update to support "halting" events

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ githubcommits://?exclude_additions={EXCLUDE_ADDITIONS}&exclude_modification={EXC
 | exclude_additions| boolean | A flag to indicate that new additions in a commit should be ignored. | no |
 | exclude_modifications| boolean | A flag to indicate that modifications in a commit should be ignored. | no |
 | exclude_deletions | boolean | A flag to indicate that deletions in a commit should be ignored. | no |
+| prepend_message | boolean | An optional boolean value to prepend the commit message to the final output. This takes the form of '#message,{COMMIT_MESSAGE},' | no |
+| prepend_author | boolean | An optional boolean value to prepend the name of the commit author to the final output. This takes the form of '#author,{COMMIT_AUTHOR},' | no |
+| halt_on_message | string | An optional regular expression that will be compared to the commit message; if it matches the transformer will return an error with code `webhookd.HaltEvent` | no | 
+| halt_on_author | string | An optional regular expression that will be compared to the commit author; if it matches the transformer will return an error with code `webhookd.HaltEvent` | no |
 
 ### GitHubRepo
 
@@ -76,6 +80,10 @@ githubrepo://?exclude_additions={EXCLUDE_ADDITIONS}&exclude_modification={EXCLUD
 | exclude_additions| boolean | A flag to indicate that new additions in a commit should be ignored. | no |
 | exclude_modifications| boolean | A flag to indicate that modifications in a commit should be ignored. | no |
 | exclude_deletions | boolean | A flag to indicate that deletions in a commit should be ignored. | no |
+| prepend_message | boolean | An optional boolean value to prepend the commit message to the final output. This takes the form of '#message,{COMMIT_MESSAGE},' | no |
+| prepend_author | boolean | An optional boolean value to prepend the name of the commit author to the final output. This takes the form of '#author,{COMMIT_AUTHOR},' | no |
+| halt_on_message | string | An optional regular expression that will be compared to the commit message; if it matches the transformer will return an error with code `webhookd.HaltEvent` | no | 
+| halt_on_author | string | An optional regular expression that will be compared to the commit author; if it matches the transformer will return an error with code `webhookd.HaltEvent` | no |
 
 ## See also
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/google/go-github/v48 v48.1.0
 	github.com/sfomuseum/go-flags v0.10.0
-	github.com/whosonfirst/go-webhookd/v3 v3.1.2
+	github.com/whosonfirst/go-webhookd/v3 v3.2.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1318,8 +1318,8 @@ github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1
 github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vultr/govultr/v2 v2.17.2/go.mod h1:ZFOKGWmgjytfyjeyAdhQlSWwTjh2ig+X49cAp50dzXI=
 github.com/whosonfirst/go-sanitize v0.1.0/go.mod h1:p/emgbafMM0p5iVAz2XWwecYPl06Tw4Jos9rhTKIrt8=
-github.com/whosonfirst/go-webhookd/v3 v3.1.2 h1:vRxw7uNTSOy1HRZ9ZwpxrnMo9FKNsXlC6ZUCAwGVQ8A=
-github.com/whosonfirst/go-webhookd/v3 v3.1.2/go.mod h1:IGC+3aQ6OHoRi8QiGex5FNrKLDh6eIp10Bk1/5w3sGQ=
+github.com/whosonfirst/go-webhookd/v3 v3.2.0 h1:eEk1c5bNKUcrt8QwO6e5tNu5Lx0+4wxnwak1NTpW75w=
+github.com/whosonfirst/go-webhookd/v3 v3.2.0/go.mod h1:IGC+3aQ6OHoRi8QiGex5FNrKLDh6eIp10Bk1/5w3sGQ=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=

--- a/receiver.go
+++ b/receiver.go
@@ -111,7 +111,7 @@ func (wh GitHubReceiver) Receive(ctx context.Context, req *http.Request) ([]byte
 	}
 
 	if event_type == "ping" {
-		err := &webhookd.WebhookError{Code: -1, Message: "ping message is a no-op"}
+		err := &webhookd.WebhookError{Code: webhookd.UnhandledEvent, Message: "ping message is a no-op"}
 		return nil, err
 	}
 

--- a/transformation.commits.go
+++ b/transformation.commits.go
@@ -38,13 +38,13 @@ type GitHubCommitsTransformation struct {
 	// ExcludeDeletions is a boolean flag to exclude deleted files from the final output.
 	ExcludeDeletions bool
 	// A boolean flag signaling the commit message should be prepended to the top of the final output in the form of '#message {COMMIT_MESSAGE}'
-	prepend_message  bool
-	// A boolean flag signaling the commit author should be prepended to the top of the final output in the form of '#author {COMMIT_AUTHOR}'	
-	prepend_author   bool
+	prepend_message bool
+	// A boolean flag signaling the commit author should be prepended to the top of the final output in the form of '#author {COMMIT_AUTHOR}'
+	prepend_author bool
 	// An optional regular expression that will be compared to the commit message; if it matches the transformer will return an error with code `webhookd.HaltEvent`
-	halt_on_message  *regexp.Regexp
-	// An optional regular expression that will be compared to the commit author; if it matches the transformer will return an error with code `webhookd.HaltEvent`	
-	halt_on_author   *regexp.Regexp
+	halt_on_message *regexp.Regexp
+	// An optional regular expression that will be compared to the commit author; if it matches the transformer will return an error with code `webhookd.HaltEvent`
+	halt_on_author *regexp.Regexp
 }
 
 // NewGitHubCommitsTransformation() creates a new `GitHubCommitsTransformation` instance, configured by 'uri'
@@ -59,7 +59,7 @@ type GitHubCommitsTransformation struct {
 // * `?prepend_message` An optional boolean value to prepend the commit message to the final output. This takes the form of '#message,{COMMIT_MESSAGE},'
 // * `?prepend_author` An optional boolean value to prepend the name of the commit author to the final output. This takes the form of '#author,{COMMIT_AUTHOR},'
 // * `?halt_on_message` An optional regular expression that will be compared to the commit message; if it matches the transformer will return an error with code `webhookd.HaltEvent`
-// * `?halt_on_author` An optional regular expression that will be compared to the commit author; if it matches the transformer will return an error with code `webhookd.HaltEvent`	
+// * `?halt_on_author` An optional regular expression that will be compared to the commit author; if it matches the transformer will return an error with code `webhookd.HaltEvent`
 func NewGitHubCommitsTransformation(ctx context.Context, uri string) (webhookd.WebhookTransformation, error) {
 
 	u, err := url.Parse(uri)
@@ -208,11 +208,13 @@ func (p *GitHubCommitsTransformation) Transform(ctx context.Context, body []byte
 	wr := csv.NewWriter(buf)
 
 	if p.prepend_message {
-		wr.Write([]string{"#message", *event.HeadCommit.Message, ""})
+		v := fmt.Sprintf("#message %s", *event.HeadCommit.Message)
+		wr.Write([]string{v, "", ""})
 	}
 
 	if p.prepend_author {
-		wr.Write([]string{"#author", *event.HeadCommit.Author.Name, ""})
+		v := fmt.Sprintf("#author %s", *event.HeadCommit.Author.Name)
+		wr.Write([]string{v, "", ""})
 	}
 
 	repo := event.Repo

--- a/transformation.commits.go
+++ b/transformation.commits.go
@@ -10,6 +10,7 @@ import (
 	"github.com/whosonfirst/go-webhookd/v3"
 	"github.com/whosonfirst/go-webhookd/v3/transformation"
 	"net/url"
+	"regexp"
 	"strconv"
 )
 
@@ -36,8 +37,14 @@ type GitHubCommitsTransformation struct {
 	ExcludeModifications bool
 	// ExcludeDeletions is a boolean flag to exclude deleted files from the final output.
 	ExcludeDeletions bool
+	// A boolean flag signaling the commit message should be prepended to the top of the final output in the form of '#message {COMMIT_MESSAGE}'
 	prepend_message  bool
+	// A boolean flag signaling the commit author should be prepended to the top of the final output in the form of '#author {COMMIT_AUTHOR}'	
 	prepend_author   bool
+	// An optional regular expression that will be compared to the commit message; if it matches the transformer will return an error with code `webhookd.HaltEvent`
+	halt_on_message  *regexp.Regexp
+	// An optional regular expression that will be compared to the commit author; if it matches the transformer will return an error with code `webhookd.HaltEvent`	
+	halt_on_author   *regexp.Regexp
 }
 
 // NewGitHubCommitsTransformation() creates a new `GitHubCommitsTransformation` instance, configured by 'uri'
@@ -51,6 +58,8 @@ type GitHubCommitsTransformation struct {
 // * `?exclude_deletions` An optional boolean value to exclude deleted files from the final output.
 // * `?prepend_message` An optional boolean value to prepend the commit message to the final output. This takes the form of '#message,{COMMIT_MESSAGE},'
 // * `?prepend_author` An optional boolean value to prepend the name of the commit author to the final output. This takes the form of '#author,{COMMIT_AUTHOR},'
+// * `?halt_on_message` An optional regular expression that will be compared to the commit message; if it matches the transformer will return an error with code `webhookd.HaltEvent`
+// * `?halt_on_author` An optional regular expression that will be compared to the commit author; if it matches the transformer will return an error with code `webhookd.HaltEvent`	
 func NewGitHubCommitsTransformation(ctx context.Context, uri string) (webhookd.WebhookTransformation, error) {
 
 	u, err := url.Parse(uri)
@@ -61,11 +70,14 @@ func NewGitHubCommitsTransformation(ctx context.Context, uri string) (webhookd.W
 
 	q := u.Query()
 
-	str_additions := q.Get("exclude_additions")
-	str_modifications := q.Get("exclude_modifications")
-	str_deletions := q.Get("exclude_deletions")
-	str_message := q.Get("prepend_message")
-	str_author := q.Get("prepend_author")
+	q_additions := q.Get("exclude_additions")
+	q_modifications := q.Get("exclude_modifications")
+	q_deletions := q.Get("exclude_deletions")
+	q_message := q.Get("prepend_message")
+	q_author := q.Get("prepend_author")
+
+	q_halt_on_message := q.Get("halt_on_message")
+	q_halt_on_author := q.Get("halt_on_author")
 
 	exclude_additions := false
 	exclude_modifications := false
@@ -74,56 +86,56 @@ func NewGitHubCommitsTransformation(ctx context.Context, uri string) (webhookd.W
 	prepend_message := false
 	prepend_author := false
 
-	if str_additions != "" {
+	if q_additions != "" {
 
-		v, err := strconv.ParseBool(str_additions)
+		v, err := strconv.ParseBool(q_additions)
 
 		if err != nil {
-			return nil, fmt.Errorf("Failed to parse '%s', %w", str_additions, err)
+			return nil, fmt.Errorf("Failed to parse '%s', %w", q_additions, err)
 		}
 
 		exclude_additions = v
 	}
 
-	if str_modifications != "" {
+	if q_modifications != "" {
 
-		v, err := strconv.ParseBool(str_modifications)
+		v, err := strconv.ParseBool(q_modifications)
 
 		if err != nil {
-			return nil, fmt.Errorf("Failed to parse '%s', %w", str_modifications, err)
+			return nil, fmt.Errorf("Failed to parse '%s', %w", q_modifications, err)
 		}
 
 		exclude_modifications = v
 	}
 
-	if str_deletions != "" {
+	if q_deletions != "" {
 
-		v, err := strconv.ParseBool(str_deletions)
+		v, err := strconv.ParseBool(q_deletions)
 
 		if err != nil {
-			return nil, fmt.Errorf("Failed to parse '%s', %w", str_deletions, err)
+			return nil, fmt.Errorf("Failed to parse '%s', %w", q_deletions, err)
 		}
 
 		exclude_deletions = v
 	}
 
-	if str_message != "" {
+	if q_message != "" {
 
-		v, err := strconv.ParseBool(str_message)
+		v, err := strconv.ParseBool(q_message)
 
 		if err != nil {
-			return nil, fmt.Errorf("Failed to parse '%s', %w", str_message, err)
+			return nil, fmt.Errorf("Failed to parse '%s', %w", q_message, err)
 		}
 
 		prepend_message = v
 	}
 
-	if str_author != "" {
+	if q_author != "" {
 
-		v, err := strconv.ParseBool(str_author)
+		v, err := strconv.ParseBool(q_author)
 
 		if err != nil {
-			return nil, fmt.Errorf("Failed to parse '%s', %w", str_author, err)
+			return nil, fmt.Errorf("Failed to parse '%s', %w", q_author, err)
 		}
 
 		prepend_author = v
@@ -135,6 +147,28 @@ func NewGitHubCommitsTransformation(ctx context.Context, uri string) (webhookd.W
 		ExcludeDeletions:     exclude_deletions,
 		prepend_message:      prepend_message,
 		prepend_author:       prepend_author,
+	}
+
+	if q_halt_on_message != "" {
+
+		r, err := regexp.Compile(q_halt_on_message)
+
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse ?halt_on_message= parameter, %w", err)
+		}
+
+		p.halt_on_message = r
+	}
+
+	if q_halt_on_author != "" {
+
+		r, err := regexp.Compile(q_halt_on_author)
+
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse ?halt_on_author= parameter, %w", err)
+		}
+
+		p.halt_on_author = r
 	}
 
 	return &p, nil
@@ -157,6 +191,16 @@ func (p *GitHubCommitsTransformation) Transform(ctx context.Context, body []byte
 
 	if err != nil {
 		err := &webhookd.WebhookError{Code: 999, Message: err.Error()}
+		return nil, err
+	}
+
+	if p.halt_on_message != nil && p.halt_on_message.MatchString(*event.HeadCommit.Message) {
+		err := &webhookd.WebhookError{Code: webhookd.HaltEvent, Message: "Halt"}
+		return nil, err
+	}
+
+	if p.halt_on_author != nil && p.halt_on_author.MatchString(*event.HeadCommit.Author.Name) {
+		err := &webhookd.WebhookError{Code: webhookd.HaltEvent, Message: "Halt"}
 		return nil, err
 	}
 

--- a/transformation.commits_test.go
+++ b/transformation.commits_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/csv"
 	"fmt"
+	"github.com/whosonfirst/go-webhookd/v3"
 	"github.com/whosonfirst/go-webhookd/v3/transformation"
 	"io"
 	"os"
@@ -65,5 +66,111 @@ func TestGitHubCommitsTransformation(t *testing.T) {
 
 	if len(rows) != expected_rows {
 		t.Fatalf("Unexpected row coutn: %d", len(rows))
+	}
+}
+
+func TestGitHubCommitsTransformationWithPrepend(t *testing.T) {
+
+	expected_hash := "1f7cff82034f23c836682db2102e2a79541dcc9afb64e2fe189b306c8591c004"
+	expected_rows := 1608
+
+	msg := "fixtures/events/flights.json"
+	fh, err := os.Open(msg)
+
+	if err != nil {
+		t.Fatalf("Failed to open %s, %v", msg, err)
+	}
+
+	defer fh.Close()
+
+	body, err := io.ReadAll(fh)
+
+	if err != nil {
+		t.Fatalf("Failed to read %s, %v", msg, err)
+	}
+
+	ctx := context.Background()
+
+	tr, err := transformation.NewTransformation(ctx, "githubcommits://?prepend_message=true")
+
+	if err != nil {
+		t.Fatalf("Failed to create new transformation, %v", err)
+	}
+
+	data, err2 := tr.Transform(ctx, body)
+
+	if err2 != nil {
+		t.Fatalf("Failed to transform message, %v", err2)
+	}
+
+	sum := sha256.Sum256([]byte(data))
+	hash := fmt.Sprintf("%x", sum)
+
+	if hash != expected_hash {
+		t.Fatalf("Unexpected hash of commit data: %s", hash)
+	}
+
+	r := bytes.NewReader(data)
+
+	csv_r := csv.NewReader(r)
+
+	rows, err := csv_r.ReadAll()
+
+	if err != nil {
+		t.Fatalf("Failed to read CSV data, %v", err)
+	}
+
+	if len(rows) != expected_rows {
+		t.Fatalf("Unexpected row coutn: %d", len(rows))
+	}
+
+	r = bytes.NewReader(data)
+	csv_r = csv.NewReader(r)
+
+	row, err := csv_r.Read()
+
+	if err != nil {
+		t.Fatalf("Failed to read row, %v", err)
+	}
+
+	if row[0] != "#message append SWIM data for 20200521" {
+		t.Fatalf("Unexpected value for first row '%s'", row[0])
+	}
+
+}
+
+func TestGitHubCommitsTransformationWithHalt(t *testing.T) {
+
+	msg := "fixtures/events/flights.json"
+	fh, err := os.Open(msg)
+
+	if err != nil {
+		t.Fatalf("Failed to open %s, %v", msg, err)
+	}
+
+	defer fh.Close()
+
+	body, err := io.ReadAll(fh)
+
+	if err != nil {
+		t.Fatalf("Failed to read %s, %v", msg, err)
+	}
+
+	ctx := context.Background()
+
+	tr, err := transformation.NewTransformation(ctx, "githubcommits://?halt_on_message=SWIM")
+
+	if err != nil {
+		t.Fatalf("Failed to create new transformation, %v", err)
+	}
+
+	_, err2 := tr.Transform(ctx, body)
+
+	if err2 == nil {
+		t.Fatalf("Expected error transforming message")
+	}
+
+	if err2.Code != webhookd.HaltEvent {
+		t.Fatalf("Expected halt event")
 	}
 }

--- a/transformation.repo.go
+++ b/transformation.repo.go
@@ -36,13 +36,13 @@ type GitHubRepoTransformation struct {
 	// ExcludeDeletions is a boolean flag to exclude updated (modified) files from consideration.
 	ExcludeDeletions bool
 	// A boolean flag signaling the commit message should be prepended to the top of the final output in the form of '#message {COMMIT_MESSAGE}'
-	prepend_message  bool
-	// A boolean flag signaling the commit author should be prepended to the top of the final output in the form of '#author {COMMIT_AUTHOR}'	
-	prepend_author   bool
+	prepend_message bool
+	// A boolean flag signaling the commit author should be prepended to the top of the final output in the form of '#author {COMMIT_AUTHOR}'
+	prepend_author bool
 	// An optional regular expression that will be compared to the commit message; if it matches the transformer will return an error with code `webhookd.HaltEvent`
-	halt_on_message  *regexp.Regexp
-	// An optional regular expression that will be compared to the commit author; if it matches the transformer will return an error with code `webhookd.HaltEvent`	
-	halt_on_author   *regexp.Regexp
+	halt_on_message *regexp.Regexp
+	// An optional regular expression that will be compared to the commit author; if it matches the transformer will return an error with code `webhookd.HaltEvent`
+	halt_on_author *regexp.Regexp
 }
 
 // NewGitHubRepoTransformation() creates a new `GitHubRepoTransformation` instance, configured by 'uri'
@@ -57,7 +57,7 @@ type GitHubRepoTransformation struct {
 // * `?prepend_message` An optional boolean value to prepend the commit message to the final output. This takes the form of '#message {COMMIT_MESSAGE}'
 // * `?prepend_author` An optional boolean value to prepend the name of the commit author to the final output. This takes the form of '#author {COMMIT_AUTHOR}'
 // * `?halt_on_message` An optional regular expression that will be compared to the commit message; if it matches the transformer will return an error with code `webhookd.HaltEvent`
-// * `?halt_on_author` An optional regular expression that will be compared to the commit author; if it matches the transformer will return an error with code `webhookd.HaltEvent`	
+// * `?halt_on_author` An optional regular expression that will be compared to the commit author; if it matches the transformer will return an error with code `webhookd.HaltEvent`
 func NewGitHubRepoTransformation(ctx context.Context, uri string) (webhookd.WebhookTransformation, error) {
 
 	u, err := url.Parse(uri)

--- a/transformation.repo.go
+++ b/transformation.repo.go
@@ -9,6 +9,7 @@ import (
 	"github.com/whosonfirst/go-webhookd/v3"
 	"github.com/whosonfirst/go-webhookd/v3/transformation"
 	"net/url"
+	"regexp"
 	"strconv"
 )
 
@@ -34,8 +35,14 @@ type GitHubRepoTransformation struct {
 	ExcludeModifications bool
 	// ExcludeDeletions is a boolean flag to exclude updated (modified) files from consideration.
 	ExcludeDeletions bool
+	// A boolean flag signaling the commit message should be prepended to the top of the final output in the form of '#message {COMMIT_MESSAGE}'
 	prepend_message  bool
+	// A boolean flag signaling the commit author should be prepended to the top of the final output in the form of '#author {COMMIT_AUTHOR}'	
 	prepend_author   bool
+	// An optional regular expression that will be compared to the commit message; if it matches the transformer will return an error with code `webhookd.HaltEvent`
+	halt_on_message  *regexp.Regexp
+	// An optional regular expression that will be compared to the commit author; if it matches the transformer will return an error with code `webhookd.HaltEvent`	
+	halt_on_author   *regexp.Regexp
 }
 
 // NewGitHubRepoTransformation() creates a new `GitHubRepoTransformation` instance, configured by 'uri'
@@ -49,6 +56,8 @@ type GitHubRepoTransformation struct {
 // * `?exclude_deletions` An optional boolean value to exclude deleted files from consideration.
 // * `?prepend_message` An optional boolean value to prepend the commit message to the final output. This takes the form of '#message {COMMIT_MESSAGE}'
 // * `?prepend_author` An optional boolean value to prepend the name of the commit author to the final output. This takes the form of '#author {COMMIT_AUTHOR}'
+// * `?halt_on_message` An optional regular expression that will be compared to the commit message; if it matches the transformer will return an error with code `webhookd.HaltEvent`
+// * `?halt_on_author` An optional regular expression that will be compared to the commit author; if it matches the transformer will return an error with code `webhookd.HaltEvent`	
 func NewGitHubRepoTransformation(ctx context.Context, uri string) (webhookd.WebhookTransformation, error) {
 
 	u, err := url.Parse(uri)
@@ -59,11 +68,14 @@ func NewGitHubRepoTransformation(ctx context.Context, uri string) (webhookd.Webh
 
 	q := u.Query()
 
-	str_additions := q.Get("exclude_additions")
-	str_modifications := q.Get("exclude_modifications")
-	str_deletions := q.Get("exclude_deletions")
-	str_message := q.Get("prepend_message")
-	str_author := q.Get("prepend_author")
+	q_additions := q.Get("exclude_additions")
+	q_modifications := q.Get("exclude_modifications")
+	q_deletions := q.Get("exclude_deletions")
+	q_message := q.Get("prepend_message")
+	q_author := q.Get("prepend_author")
+
+	q_halt_on_message := q.Get("halt_on_message")
+	q_halt_on_author := q.Get("halt_on_author")
 
 	exclude_additions := false
 	exclude_modifications := false
@@ -72,56 +84,56 @@ func NewGitHubRepoTransformation(ctx context.Context, uri string) (webhookd.Webh
 	prepend_message := false
 	prepend_author := false
 
-	if str_additions != "" {
+	if q_additions != "" {
 
-		v, err := strconv.ParseBool(str_additions)
+		v, err := strconv.ParseBool(q_additions)
 
 		if err != nil {
-			return nil, fmt.Errorf("Failed to parse '%s', %w", str_additions, err)
+			return nil, fmt.Errorf("Failed to parse '%s', %w", q_additions, err)
 		}
 
 		exclude_additions = v
 	}
 
-	if str_modifications != "" {
+	if q_modifications != "" {
 
-		v, err := strconv.ParseBool(str_modifications)
+		v, err := strconv.ParseBool(q_modifications)
 
 		if err != nil {
-			return nil, fmt.Errorf("Failed to parse '%s', %w", str_modifications, err)
+			return nil, fmt.Errorf("Failed to parse '%s', %w", q_modifications, err)
 		}
 
 		exclude_modifications = v
 	}
 
-	if str_deletions != "" {
+	if q_deletions != "" {
 
-		v, err := strconv.ParseBool(str_deletions)
+		v, err := strconv.ParseBool(q_deletions)
 
 		if err != nil {
-			return nil, fmt.Errorf("Failed to parse '%s', %w", str_deletions, err)
+			return nil, fmt.Errorf("Failed to parse '%s', %w", q_deletions, err)
 		}
 
 		exclude_deletions = v
 	}
 
-	if str_message != "" {
+	if q_message != "" {
 
-		v, err := strconv.ParseBool(str_message)
+		v, err := strconv.ParseBool(q_message)
 
 		if err != nil {
-			return nil, fmt.Errorf("Failed to parse '%s', %w", str_message, err)
+			return nil, fmt.Errorf("Failed to parse '%s', %w", q_message, err)
 		}
 
 		prepend_message = v
 	}
 
-	if str_author != "" {
+	if q_author != "" {
 
-		v, err := strconv.ParseBool(str_author)
+		v, err := strconv.ParseBool(q_author)
 
 		if err != nil {
-			return nil, fmt.Errorf("Failed to parse '%s', %w", str_author, err)
+			return nil, fmt.Errorf("Failed to parse '%s', %w", q_author, err)
 		}
 
 		prepend_author = v
@@ -133,6 +145,28 @@ func NewGitHubRepoTransformation(ctx context.Context, uri string) (webhookd.Webh
 		ExcludeDeletions:     exclude_deletions,
 		prepend_message:      prepend_message,
 		prepend_author:       prepend_author,
+	}
+
+	if q_halt_on_message != "" {
+
+		r, err := regexp.Compile(q_halt_on_message)
+
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse ?halt_on_message= parameter, %w", err)
+		}
+
+		p.halt_on_message = r
+	}
+
+	if q_halt_on_author != "" {
+
+		r, err := regexp.Compile(q_halt_on_author)
+
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse ?halt_on_author= parameter, %w", err)
+		}
+
+		p.halt_on_author = r
 	}
 
 	return &p, nil
@@ -155,6 +189,16 @@ func (p *GitHubRepoTransformation) Transform(ctx context.Context, body []byte) (
 
 	if err != nil {
 		err := &webhookd.WebhookError{Code: 999, Message: err.Error()}
+		return nil, err
+	}
+
+	if p.halt_on_message != nil && p.halt_on_message.MatchString(*event.HeadCommit.Message) {
+		err := &webhookd.WebhookError{Code: webhookd.HaltEvent, Message: "Halt"}
+		return nil, err
+	}
+
+	if p.halt_on_author != nil && p.halt_on_author.MatchString(*event.HeadCommit.Author.Name) {
+		err := &webhookd.WebhookError{Code: webhookd.HaltEvent, Message: "Halt"}
 		return nil, err
 	}
 

--- a/transformation.repo_test.go
+++ b/transformation.repo_test.go
@@ -3,6 +3,7 @@ package github
 import (
 	"bytes"
 	"context"
+	"github.com/whosonfirst/go-webhookd/v3"
 	"github.com/whosonfirst/go-webhookd/v3/transformation"
 	"io"
 	"os"
@@ -46,4 +47,80 @@ func TestGitHubRepoTransformation(t *testing.T) {
 		t.Fatalf("Unexpected repo: %s", string(repo_name))
 	}
 
+}
+
+func TestGitHubRepoTransformationWithPrepend(t *testing.T) {
+
+	expected_repo := []byte(`#author sfomuseumbot
+sfomuseum-data-flights-2020-05`)
+
+	msg := "fixtures/events/flights.json"
+	fh, err := os.Open(msg)
+
+	if err != nil {
+		t.Fatalf("Failed to open %s, %v", msg, err)
+	}
+
+	defer fh.Close()
+
+	body, err := io.ReadAll(fh)
+
+	if err != nil {
+		t.Fatalf("Failed to read %s, %v", msg, err)
+	}
+
+	ctx := context.Background()
+
+	tr, err := transformation.NewTransformation(ctx, "githubrepo://?prepend_author=true")
+
+	if err != nil {
+		t.Fatalf("Failed to create new transformation, %v", err)
+	}
+
+	output, err2 := tr.Transform(ctx, body)
+
+	if err2 != nil {
+		t.Fatalf("Failed to transform message, %v", err2)
+	}
+
+	if !bytes.Equal(output, expected_repo) {
+		t.Fatalf("Unexpected output: '%s'", string(output))
+	}
+
+}
+
+func TestGitHubRepoTransformationWithHalt(t *testing.T) {
+
+	msg := "fixtures/events/flights.json"
+	fh, err := os.Open(msg)
+
+	if err != nil {
+		t.Fatalf("Failed to open %s, %v", msg, err)
+	}
+
+	defer fh.Close()
+
+	body, err := io.ReadAll(fh)
+
+	if err != nil {
+		t.Fatalf("Failed to read %s, %v", msg, err)
+	}
+
+	ctx := context.Background()
+
+	tr, err := transformation.NewTransformation(ctx, "githubrepo://?halt_on_author=sfomuseumbot")
+
+	if err != nil {
+		t.Fatalf("Failed to create new transformation, %v", err)
+	}
+
+	_, err2 := tr.Transform(ctx, body)
+
+	if err2 == nil {
+		t.Fatalf("Expected error transforming message")
+	}
+
+	if err2.Code != webhookd.HaltEvent {
+		t.Fatalf("Expected halt event")
+	}
 }

--- a/vendor/github.com/whosonfirst/go-webhookd/v3/dispatcher/log.go
+++ b/vendor/github.com/whosonfirst/go-webhookd/v3/dispatcher/log.go
@@ -25,7 +25,7 @@ type LogDispatcher struct {
 
 // NewLogDispatcher returns a new `LogDispatcher` instance configured by 'uri' in the form of:
 //
-// 	log://
+//	log://
 //
 // Messasges are dispatched to the default `log.Default()` instance.
 func NewLogDispatcher(ctx context.Context, uri string) (webhookd.WebhookDispatcher, error) {

--- a/vendor/github.com/whosonfirst/go-webhookd/v3/error.go
+++ b/vendor/github.com/whosonfirst/go-webhookd/v3/error.go
@@ -4,6 +4,10 @@ import (
 	"fmt"
 )
 
+const UnhandledEvent int = -1
+
+const HaltEvent int = -2
+
 // WebhookError implements the `error` interface for wrapping webhookd error codes and messages.
 type WebhookError struct {
 	error
@@ -16,4 +20,9 @@ type WebhookError struct {
 // Error() returns a string containing both the status code and descriptive message associated with an error.
 func (e WebhookError) Error() string {
 	return fmt.Sprintf("%d %s", e.Code, e.Message)
+}
+
+// String returns a string representation of 'e'.
+func (e WebhookError) String() string {
+	return e.Error()
 }

--- a/vendor/github.com/whosonfirst/go-webhookd/v3/receiver/insecure.go
+++ b/vendor/github.com/whosonfirst/go-webhookd/v3/receiver/insecure.go
@@ -24,7 +24,7 @@ type InsecureReceiver struct {
 
 // NewInsecureReceiver returns a new `InsecureReceiver` instance configured by 'uri' in the form of:
 //
-// 	insecure://
+//	insecure://
 func NewInsecureReceiver(ctx context.Context, uri string) (webhookd.WebhookReceiver, error) {
 
 	wh := InsecureReceiver{}

--- a/vendor/github.com/whosonfirst/go-webhookd/v3/transformation/chicken.go
+++ b/vendor/github.com/whosonfirst/go-webhookd/v3/transformation/chicken.go
@@ -28,7 +28,7 @@ type ChickenTransformation struct {
 
 // NewInsecureTransformation returns a new `ChickenTransformation` instance configured by 'uri' in the form of:
 //
-// 	chicken://{LANGUAGE_TAG}?{PARAMETERS}
+//	chicken://{LANGUAGE_TAG}?{PARAMETERS}
 //
 // Where {LANGUAGE_TAG} is any valid language tag supported by the `aaronland/go-chicken` package. Valid {PARAMETERS} are:
 // * `clucking={BOOLEAN}` A boolean flag to indicate whether messages should be transformed in the form of chicken noises.

--- a/vendor/github.com/whosonfirst/go-webhookd/v3/transformation/null.go
+++ b/vendor/github.com/whosonfirst/go-webhookd/v3/transformation/null.go
@@ -23,7 +23,7 @@ type NullTransformation struct {
 
 // NewInsecureTransformation returns a new `NullTransformation` instance configured by 'uri' in the form of:
 //
-// 	null://
+//	null://
 func NewNullTransformation(ctx context.Context, uri string) (webhookd.WebhookTransformation, error) {
 
 	p := NullTransformation{}

--- a/vendor/github.com/whosonfirst/go-webhookd/v3/webhookd.go
+++ b/vendor/github.com/whosonfirst/go-webhookd/v3/webhookd.go
@@ -24,13 +24,13 @@ type WebhookReceiver interface {
 	Receive(context.Context, *http.Request) ([]byte, *WebhookError)
 }
 
-//WebhookTransformation is an interface that defines methods for altering (transforming) the body of a (webhook) message after receipt.
+// WebhookTransformation is an interface that defines methods for altering (transforming) the body of a (webhook) message after receipt.
 type WebhookTransformation interface {
 	// Transforms() alters the body of a (webhook) message (according to rules defined by the package implementing the `WebhookTransformation` interface).
 	Transform(context.Context, []byte) ([]byte, *WebhookError)
 }
 
-//WebhookDispatcher is an interface that defines methods for relaying the body of a (webhook) message after it has been transformed.
+// WebhookDispatcher is an interface that defines methods for relaying the body of a (webhook) message after it has been transformed.
 type WebhookDispatcher interface {
 	// Dispatch() relays the body of a message (according to rules defined defined by the package implementing the `WebhookDispatcher` interface).
 	Dispatch(context.Context, []byte) *WebhookError

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -53,7 +53,7 @@ github.com/googleapis/gax-go/v2/internal
 # github.com/sfomuseum/go-flags v0.10.0
 ## explicit; go 1.16
 github.com/sfomuseum/go-flags/flagset
-# github.com/whosonfirst/go-webhookd/v3 v3.1.2
+# github.com/whosonfirst/go-webhookd/v3 v3.2.0
 ## explicit; go 1.18
 github.com/whosonfirst/go-webhookd/v3
 github.com/whosonfirst/go-webhookd/v3/config


### PR DESCRIPTION
* Update to use `whosonfirst/go-webhookd-github` v3.2.0
* Add support for `?prepend_*` and `?halt_on_*` hooks